### PR TITLE
chore(eslint): features/shared 의 recoil/@store import 금지

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,40 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "src/features/**/*.{ts,tsx}",
+          "src/shared/**/*.{ts,tsx}"
+        ],
+        "excludedFiles": [
+          "**/__tests__/**",
+          "**/__mocks__/**"
+        ],
+        "rules": {
+          "no-restricted-imports": [
+            "error",
+            {
+              "patterns": [
+                {
+                  "group": [
+                    "recoil"
+                  ],
+                  "message": "전역 상태(Recoil)는 pages/ 에서만 접근하세요. features/shared 는 props/context 로 받아 쓰세요."
+                },
+                {
+                  "group": [
+                    "@store/*",
+                    "**/store/*"
+                  ],
+                  "message": "atom/selector 는 pages/ 에서만 import 하세요. features/shared 는 props/context 로 받아 쓰세요."
+                }
+              ]
+            }
+          ]
+        }
+      }
     ]
   },
   "browserslist": {


### PR DESCRIPTION
## 배경

직전 PR (#20) 로 features/, shared/ 의 Recoil 직접 구독을 모두 제거했음. 본 PR 은 같은 위반이 다시 들어오지 못하도록 ESLint `no-restricted-imports` 룰로 컴파일 타임에 차단.

## 변경 사항

`package.json > eslintConfig.overrides` 에 룰 추가:

- 대상: \`src/features/**/*.{ts,tsx}\`, \`src/shared/**/*.{ts,tsx}\`
- 예외: \`**/__tests__/**\`, \`**/__mocks__/**\`
- 차단 패턴:
  - \`recoil\` → "전역 상태는 pages/ 에서만 접근하세요"
  - \`@store/*\`, \`**/store/*\` → "atom/selector 는 pages/ 에서만 import"

## 동작 방식

`features/`/`shared/` 에서 누군가 `import { useRecoilValue } from "recoil"` 또는 `import { rc_xxx } from "@store/global"` 을 추가하면 ESLint error 로 빌드 실패.

## 테스트

- `pnpm build` → 성공, 새 경고/오류 없음 (위반 0건 확인)
- 룰 적용 범위는 features/shared 만이며 pages/, app/ 등은 영향 없음

## 영향 범위

- 빌드/린트 파이프라인만. 런타임 동작 변화 없음.

## 후속

전역 상태 경계 6단계 완료. 계획 문서 `docs/plans/2026-04-07-refactor-global-state-boundary-design.md` 의 완료 기준 체크 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)