### PR TITLE
refactor: drop Container/Component naming across features

### DIFF
--- a/docs/plans/2026-04-07-container-component-naming-cleanup.md
+++ b/docs/plans/2026-04-07-container-component-naming-cleanup.md
@@ -1,0 +1,116 @@
+# Container/Component 네이밍 정리
+
+작성일: 2026-04-07
+상위 계획: `docs/plans/2026-04-07-refactor-global-state-boundary-design.md` (완료 기준 정리)
+브랜치명 제안: `refactor/rename-container-component`
+
+## 배경
+
+리팩토링 계획의 **완료 기준** 중 하나:
+> - [ ] `*Container.tsx` / `*Component.tsx` 파일 패턴 소멸
+
+5단계까지 주요 program feature 들은 Container/Component 패턴을 제거했지만, 주변 feature 와 일부 wrapper 파일에 레거시 네이밍이 남아 있다. 이 작업은 **단순 리네임 + import 경로 수정** 이며 로직 변경이 없다.
+
+## 전제
+
+**이 작업은 6단계(ESLint 경계 강제 + 잔여 lift) 작업이 먼저 끝난 후** 진행하는 것을 권장한다. 이유:
+- 6단계에서 Container 파일들을 lift 하면서 일부는 자연스럽게 리네임될 수 있음
+- 순서를 반대로 하면 같은 파일을 두 번 건드려 충돌 위험
+
+## 목표
+
+- `src/features/**` 와 그 외 영역에서 `*Container.tsx` / `*Component.tsx` 네이밍을 모두 제거
+- import 경로 전수 수정
+- 기능/동작 변경 0
+
+## 비목표
+
+- 내부 로직 리팩토링
+- 파일 구조 변경 (hooks/ ui/ 도입 등은 6단계에서 끝났다고 가정)
+- 테스트 추가
+
+## 사전 조사
+
+```bash
+# 리네임 대상 전부 리스트업
+find src -name "*Container.tsx" -o -name "*Component.tsx"
+```
+
+예상 대상 (정확한 목록은 find 결과로 확정):
+- `src/features/infobar/InfoBarContainer.tsx` → `InfoBar.tsx`
+- `src/features/timebar/TimeBarContainer.tsx` → `TimeBar.tsx`
+- `src/features/statusbar/StatusBarContainer.tsx` → `StatusBar.tsx` (내부에 `components/StatusBar.tsx` 가 있으면 충돌 주의)
+- `src/features/desktop/WindowContainer.tsx` → `DesktopWindow.tsx` 또는 제거 (6단계에서 이미 축소됨)
+- `src/features/program-info/INFOProgramContainer.tsx` → `InfoProgram.tsx`
+- `src/features/program-info/INFOProgramComponent.tsx` → `InfoProgram.view.tsx` 또는 ui/ 하위로
+- 내부 `components/` 하위 `*Component.tsx` 도 점검
+- 기타
+
+## 리네임 규칙
+
+| Before | After | 비고 |
+|---|---|---|
+| `XxxContainer.tsx` | `Xxx.tsx` | 단일 컴포넌트 통합 시 |
+| `XxxComponent.tsx` | 삭제 or `ui/Xxx.tsx` | presentational 이면 `ui/` 로 이동 |
+| `components/Xxx.tsx` | `ui/Xxx.tsx` | 일관성 |
+
+충돌이 생기면 (예: `StatusBar.tsx` 가 이미 있음) → `StatusBarPanel.tsx` 같은 의미 있는 이름으로.
+
+## 작업 단계
+
+### Phase 1: 대상 목록 확정
+
+1. `find` 로 모든 `*Container.tsx` / `*Component.tsx` / `components/` 파일 리스트업
+2. 각각 리네임 후 이름 결정 (표로 정리)
+3. 충돌 여부 확인
+
+### Phase 2: 리네임 (feature 단위로 하나씩)
+
+각 feature 마다:
+
+1. `git mv` 로 파일명 변경 (내부 `components/` → `ui/` 도 함께)
+2. import 경로 수정
+   - 해당 파일을 import 하던 곳 모두 grep → 경로/이름 수정
+   - `index.ts` 의 re-export 갱신
+3. `pnpm build` 로 컴파일 에러 0 확인
+4. 작은 커밋
+
+**팁**: IDE 의 rename refactoring 기능을 쓰면 빠르지만, git history 보존을 위해 `git mv` 후 import 만 따로 수정하는 게 깔끔.
+
+### Phase 3: 테스트 파일 경로 갱신
+
+- `__tests__/XxxContainer.test.tsx` 도 같이 리네임
+- 테스트 파일 내부의 import 경로도 수정
+
+### Phase 4: 검증
+
+- `find src -name "*Container.tsx" -o -name "*Component.tsx"` 결과 0건 (또는 의도적으로 남긴 파일만)
+- `pnpm test` 전체 통과
+- `pnpm build` 성공
+- 수동 QA 간단히 (리네임만 했으므로 컴파일 성공하면 거의 OK)
+
+## 커밋/PR
+
+단일 PR 로 묶는다. 로직 변경 없는 리네임이라 리뷰 부담 적음.
+
+Commit 예시:
+- `refactor(infobar): rename InfoBarContainer to InfoBar`
+- `refactor(timebar): rename TimeBarContainer to TimeBar`
+- ...
+- `refactor: final naming cleanup pass`
+
+## 위험 요소
+
+| 위험 | 완화 |
+|---|---|
+| import 경로 누락 → 빌드 실패 | 각 리네임마다 build 실행 |
+| 동일 이름 충돌 (예: 내부 `components/StatusBar.tsx`) | 사전 조사에서 충돌 확인, 필요 시 의미 있는 이름 부여 |
+| git history 끊김 | `git mv` 사용, content 변경과 리네임을 같은 커밋에 넣지 말 것 |
+| 경로 alias 캐시 | 필요 시 node_modules/.cache 삭제 |
+
+## 완료 기준
+
+- [ ] `find src -name "*Container.tsx" -o -name "*Component.tsx"` 결과 0건
+- [ ] 모든 테스트 통과
+- [ ] 빌드 성공
+- [ ] 계획 문서 `2026-04-07-refactor-global-state-boundary-design.md` 의 "Container/Component 파일 패턴 소멸" 체크 가능

--- a/src/features/desktop/DesktopWindow.tsx
+++ b/src/features/desktop/DesktopWindow.tsx
@@ -3,7 +3,7 @@ import Window from "./components/Window";
 import { useDesktopData } from "@pages/DesktopPage/useDesktopData";
 import type { DirectoryItem } from "@pages/DesktopPage/DesktopDataContext";
 
-const WindowContainer = () => {
+const DesktopWindow = () => {
   const windowRef = useRef<HTMLDivElement | null>(null);
   const { directoryTree, openProgram } = useDesktopData();
 
@@ -22,4 +22,4 @@ const WindowContainer = () => {
   return <Window {...propDatas} />;
 };
 
-export default React.memo(WindowContainer);
+export default React.memo(DesktopWindow);

--- a/src/features/desktop/index.ts
+++ b/src/features/desktop/index.ts
@@ -1,1 +1,1 @@
-export { default as WindowContainer } from "./WindowContainer";
+export { default as DesktopWindow } from "./DesktopWindow";

--- a/src/features/infobar/InfoBar.tsx
+++ b/src/features/infobar/InfoBar.tsx
@@ -1,20 +1,20 @@
 import React from "react";
 import { useEffect } from "react";
 import { getCommitApi } from "@shared/api/git";
-import InfoBar from "./components/InfoBar";
+import InfoBarView from "./components/InfoBar";
 import useAxios from "@shared/hooks/useAxios";
 
-type InfoBarContainerProps = {
+type InfoBarProps = {
     active: boolean;
     displayLight: number;
     onChangeDisplayLight: (next: number) => void;
 };
 
-const InfoBarContainer = ({
+const InfoBar = ({
     active,
     displayLight,
     onChangeDisplayLight,
-}: InfoBarContainerProps) => {
+}: InfoBarProps) => {
     const [commit, getCommit] = useAxios(getCommitApi);
 
     // 화면밝기 조정 이벤트
@@ -35,7 +35,7 @@ const InfoBarContainer = ({
         displayLight,
         onChange,
     };
-    return <InfoBar {...propDatas} />;
+    return <InfoBarView {...propDatas} />;
 };
 
-export default InfoBarContainer;
+export default InfoBar;

--- a/src/features/infobar/index.ts
+++ b/src/features/infobar/index.ts
@@ -1,1 +1,1 @@
-export { default as InfoBarContainer } from "./InfoBarContainer";
+export { default as InfoBar } from "./InfoBar";

--- a/src/features/program-info/INFOProgramContainer.tsx
+++ b/src/features/program-info/INFOProgramContainer.tsx
@@ -1,9 +1,0 @@
-import React from "react";
-import INFOProgramComponent from "./INFOProgramComponent";
-
-const INFOProgramContainer = ({ type }) => {
-    const propDatas = { type };
-    return <INFOProgramComponent {...propDatas} />;
-};
-
-export default INFOProgramContainer;

--- a/src/features/program-info/InfoProgram.tsx
+++ b/src/features/program-info/InfoProgram.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import InfoProgramView from "./InfoProgram.view";
+
+const InfoProgram = ({ type }) => {
+    const propDatas = { type };
+    return <InfoProgramView {...propDatas} />;
+};
+
+export default InfoProgram;

--- a/src/features/program-info/InfoProgram.view.tsx
+++ b/src/features/program-info/InfoProgram.view.tsx
@@ -15,7 +15,7 @@ import gear from "@images/icons/gear_line_blue.png";
 import web from "@images/icons/web_line_blue.png";
 import companyBlue from "@images/icons/company_line_blue.png";
 
-const INFOProgramComponent = ({ type }) => {
+const InfoProgramView = ({ type }) => {
     return (
         <>
             <div
@@ -306,4 +306,4 @@ const infoProgramContentStyle = css({
         fontSize: "14px",
     },
 });
-export default INFOProgramComponent;
+export default InfoProgramView;

--- a/src/features/program-info/index.ts
+++ b/src/features/program-info/index.ts
@@ -1,2 +1,1 @@
-export { default as INFOProgramContainer } from "./INFOProgramContainer";
-export { default as INFOProgramComponent } from "./INFOProgramComponent";
+export { default as InfoProgram } from "./InfoProgram";

--- a/src/features/statusbar/StatusBar.tsx
+++ b/src/features/statusbar/StatusBar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useCallback } from "react";
 import { useRef } from "react";
-import StatusBar from "./components/StatusBar";
+import StatusBarView from "./components/StatusBar";
 import imgReact from "@images/icons/react.png";
 import imgJS from "@images/icons/javascript.png";
 import imgKit from "@images/icons/logo_kit.jpg";
@@ -10,12 +10,12 @@ import imgUser from "@images/icons/user.png";
 import imgWhaTap from "@images/icons/WhaTap_vertical_logo.png";
 import { useDesktopData } from "@pages/DesktopPage/useDesktopData";
 
-type StatusBarContainerProps = {
+type StatusBarProps = {
     active: boolean;
     onClose: () => void;
 };
 
-const StatusBarContainer = ({ active, onClose }: StatusBarContainerProps) => {
+const StatusBar = ({ active, onClose }: StatusBarProps) => {
     const { directory, directoryTree: Directory_Tree } = useDesktopData();
 
     const projectDatas = useMemo(() => {
@@ -114,7 +114,7 @@ const StatusBarContainer = ({ active, onClose }: StatusBarContainerProps) => {
         onMouseLeave,
         onClickBox,
     };
-    return <StatusBar {...propDatas} />;
+    return <StatusBarView {...propDatas} />;
 };
 
-export default StatusBarContainer;
+export default StatusBar;

--- a/src/features/statusbar/index.ts
+++ b/src/features/statusbar/index.ts
@@ -1,1 +1,1 @@
-export { default as StatusBarContainer } from "./StatusBarContainer";
+export { default as StatusBar } from "./StatusBar";

--- a/src/features/timebar/TimeBar.tsx
+++ b/src/features/timebar/TimeBar.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { useEffect } from "react";
 import { useCallback } from "react";
-import TimeBar from "./components/TimeBar";
+import TimeBarView from "./components/TimeBar";
 import useGetCurrentTime from "@shared/hooks/useGetCurrentTime";
 
-const TimeBarContainer = ({ active }: { active: boolean }) => {
+const TimeBar = ({ active }: { active: boolean }) => {
   const [date] = useState(new Date());
 
   // 실제 달력 영역
@@ -161,7 +161,7 @@ const TimeBarContainer = ({ active }: { active: boolean }) => {
     onClickUp,
     onClickDown,
   };
-  return <TimeBar {...propDatas} />;
+  return <TimeBarView {...propDatas} />;
 };
 
-export default TimeBarContainer;
+export default TimeBar;

--- a/src/features/timebar/index.ts
+++ b/src/features/timebar/index.ts
@@ -1,1 +1,1 @@
-export { default as TimeBarContainer } from "./TimeBarContainer";
+export { default as TimeBar } from "./TimeBar";

--- a/src/pages/DesktopPage/DesktopPage.tsx
+++ b/src/pages/DesktopPage/DesktopPage.tsx
@@ -24,10 +24,10 @@ import HiddenIcon from "@features/hidden-icon/HiddenIcon";
 import { TaskBar } from "@features/taskbar";
 import type { TaskbarProgramItem } from "@features/taskbar";
 import type { WindowShellItem } from "@features/window-shell";
-import InfoBarContainer from "@features/infobar/InfoBarContainer";
-import WindowContainer from "@features/desktop/WindowContainer";
-import StatusBarContainer from "@features/statusbar/StatusBarContainer";
-import TimeBarContainer from "@features/timebar/TimeBarContainer";
+import InfoBar from "@features/infobar/InfoBar";
+import DesktopWindow from "@features/desktop/DesktopWindow";
+import StatusBar from "@features/statusbar/StatusBar";
+import TimeBar from "@features/timebar/TimeBar";
 import { DesktopDataContext } from "./DesktopDataContext";
 import type {
   DesktopDataValue,
@@ -250,7 +250,7 @@ export default function DesktopPage() {
             setHiddenIcon(false);
           }}
         >
-          <WindowContainer />
+          <DesktopWindow />
           {programList.map((item) => (
             <ProgramWindow
               key={item.name}
@@ -281,16 +281,16 @@ export default function DesktopPage() {
         </div>
 
         {/* 시작 */}
-        <StatusBarContainer
+        <StatusBar
           active={activeStatus}
           onClose={handleCloseStatusBar}
         />
 
         {/* 시간 */}
-        <TimeBarContainer active={activeTime} />
+        <TimeBar active={activeTime} />
 
         {/* 정보 */}
-        <InfoBarContainer
+        <InfoBar
           active={activeInfoBar}
           displayLight={displayLight}
           onChangeDisplayLight={handleChangeDisplayLight}

--- a/src/pages/DesktopPage/renderProgramContent.tsx
+++ b/src/pages/DesktopPage/renderProgramContent.tsx
@@ -3,7 +3,7 @@ import type { WindowShellItem } from "@features/window-shell";
 import { ImageProgram } from "@features/program-image";
 import { FolderProgram } from "@features/program-folder";
 import { DOCProgram } from "@features/program-doc";
-import INFOProgramContainer from "@features/program-info/INFOProgramContainer";
+import InfoProgram from "@features/program-info/InfoProgram";
 
 /**
  * programList 항목 하나에 대한 content 영역(헤더 제외)을 렌더한다.
@@ -35,7 +35,7 @@ export const renderProgramContent = (item: WindowShellItem): ReactNode => {
         case "DOC":
             return <DOCProgram type={item.type} name={item.name} />;
         case "INFO":
-            return <INFOProgramContainer type={item.type} />;
+            return <InfoProgram type={item.type} />;
         default:
             return null;
     }


### PR DESCRIPTION
## 배경
`docs/plans/2026-04-07-refactor-global-state-boundary-design.md` 의 완료 기준 중 하나인 **`*Container.tsx` / `*Component.tsx` 파일 패턴 소멸**을 충족하기 위한 단순 리네임 작업. 세부 계획은 `docs/plans/2026-04-07-container-component-naming-cleanup.md`.

## 변경 사항
- `timebar/TimeBarContainer` → `TimeBar`
- `infobar/InfoBarContainer` → `InfoBar`
- `statusbar/StatusBarContainer` → `StatusBar`
- `desktop/WindowContainer` → `DesktopWindow` (내부 `components/Window` 와 충돌 회피)
- `program-info/INFOProgramContainer` → `InfoProgram`
- `program-info/INFOProgramComponent` → `InfoProgram.view`
- 각 feature 의 `index.ts` re-export 명 갱신
- `DesktopPage.tsx`, `renderProgramContent.tsx` import 경로/JSX 사용처 갱신

## 동작 방식
- 로직/동작 변경 0. 식별자 이름과 파일 경로만 정리.
- 내부 `components/*.tsx` 와 이름이 같은 feature entry 들은 import 시 `*View` alias 로 받아 충돌 회피.

## 테스트
- [x] `pnpm build` 성공 (compile/lint warning 은 기존과 동일)
- [ ] `pnpm test` 는 master 기준에서도 babel parser 가 한글 식별자에서 실패하는 기존 이슈가 있어 본 PR 범위 밖
- [x] `find src -name "*Container.tsx" -o -name "*Component.tsx"` 결과 0건

## 영향 범위
- features/{timebar,infobar,statusbar,desktop,program-info}
- pages/DesktopPage 의 두 파일

🤖 Generated with [Claude Code](https://claude.com/claude-code)