### PR TITLE
refactor(features): 미지정 컴포넌트 props 타입 명시

### DIFF
--- a/src/features/desktop/components/IconBox.tsx
+++ b/src/features/desktop/components/IconBox.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import defaultImg from "../../../logo.svg";
 import { css } from "@styled-system/css";
+import type { DirectoryItem } from "@pages/DesktopPage/DesktopDataContext";
 
-const IconBox = ({ item, onClick, onDoubleClick }) => {
+interface IconBoxProps {
+    item: DirectoryItem;
+    onClick: (item: DirectoryItem) => void;
+    onDoubleClick: (item: DirectoryItem) => void;
+}
+
+const IconBox = ({ item, onClick, onDoubleClick }: IconBoxProps) => {
     const { name, icon } = item;
     return (
         <div

--- a/src/features/desktop/components/Window.tsx
+++ b/src/features/desktop/components/Window.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { RefObject } from "react";
 import { css } from "@styled-system/css";
 import IconBox from "./IconBox";
+import type { DirectoryItem } from "@pages/DesktopPage/DesktopDataContext";
 
 const windowBlockStyle = css({
     width: "100%",
@@ -10,8 +11,19 @@ const windowBlockStyle = css({
     gridTemplateRows: "repeat(auto-fill, 100px)",
 });
 
-const Window = (props) => {
-    const { windowRef, iconBoxArr, onClickIcon, onDoubleClickIcon } = props;
+interface WindowProps {
+    windowRef: RefObject<HTMLDivElement | null>;
+    iconBoxArr: Array<DirectoryItem>;
+    onClickIcon: (item: DirectoryItem) => void;
+    onDoubleClickIcon: (item: DirectoryItem) => void;
+}
+
+const Window = ({
+    windowRef,
+    iconBoxArr,
+    onClickIcon,
+    onDoubleClickIcon,
+}: WindowProps) => {
     return (
         <div className={windowBlockStyle} ref={windowRef}>
             {iconBoxArr.map((item) => (

--- a/src/features/hidden-icon/components/SkillIcon.tsx
+++ b/src/features/hidden-icon/components/SkillIcon.tsx
@@ -19,7 +19,12 @@ const skillIconBlockStyle = css({
     },
 });
 
-const SkillIcon = ({ src, text }) => {
+interface SkillIconProps {
+    src: string;
+    text: string;
+}
+
+const SkillIcon = ({ src, text }: SkillIconProps) => {
     return (
         <div className={skillIconBlockStyle} title={text}>
             <img src={src} alt={text} />

--- a/src/features/infobar/components/CommitItem.tsx
+++ b/src/features/infobar/components/CommitItem.tsx
@@ -2,7 +2,16 @@ import React from "react";
 import { css } from "@styled-system/css";
 import { dateToStr } from "@shared/lib/common";
 
-const CommitItem = ({ item }) => {
+interface CommitItemProps {
+    item: {
+        commit: {
+            author: { name: string; date: string };
+            message: string;
+        };
+    };
+}
+
+const CommitItem = ({ item }: CommitItemProps) => {
     return (
         <div className={commitItemStyle}>
             <h4>{item.commit.author.name}</h4>

--- a/src/features/infobar/components/InfoBar.tsx
+++ b/src/features/infobar/components/InfoBar.tsx
@@ -4,8 +4,24 @@ import ErrorBox from "./ErrorBox";
 import sum from "@images/icons/sun.png";
 import { InfoBarBlock } from "./InfoBar.style";
 
-const InfoBar = (props) => {
-  const { active, commit, displayLight, onChange } = props;
+interface CommitData {
+  commit: {
+    author: { name: string; date: string };
+    message: string;
+  };
+}
+
+interface InfoBarViewProps {
+  active: boolean;
+  commit: {
+    data: Array<CommitData> | null;
+    error: unknown;
+  };
+  displayLight: number;
+  onChange: (e: { target: { value: string } }) => void;
+}
+
+const InfoBar = ({ active, commit, displayLight, onChange }: InfoBarViewProps) => {
   const { data, error } = commit;
 
   return (

--- a/src/features/program-info/InfoProgram.tsx
+++ b/src/features/program-info/InfoProgram.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import InfoProgramView from "./InfoProgram.view";
 
-const InfoProgram = ({ type }) => {
+interface InfoProgramProps {
+    type: string;
+}
+
+const InfoProgram = ({ type }: InfoProgramProps) => {
     const propDatas = { type };
     return <InfoProgramView {...propDatas} />;
 };

--- a/src/features/program-info/InfoProgram.view.tsx
+++ b/src/features/program-info/InfoProgram.view.tsx
@@ -15,7 +15,11 @@ import gear from "@images/icons/gear_line_blue.png";
 import web from "@images/icons/web_line_blue.png";
 import companyBlue from "@images/icons/company_line_blue.png";
 
-const InfoProgramView = ({ type }) => {
+interface InfoProgramViewProps {
+    type: string;
+}
+
+const InfoProgramView = ({ type }: InfoProgramViewProps) => {
     return (
         <>
             <div

--- a/src/features/timebar/components/TimeBar.tsx
+++ b/src/features/timebar/components/TimeBar.tsx
@@ -5,28 +5,54 @@ import { TimeBarBlock } from "./TimeBar.style";
 
 const dateArr = ["일", "월", "화", "수", "목", "금", "토"];
 
-const TimeBar = (props) => {
-  const {
-    calendarData,
-    month,
-    year,
-    calendarBodyClassName,
-    active,
+interface CalendarCell {
+  type: string;
+  data: number;
+}
 
-    cur_year,
-    cur_month,
-    cur_day,
-    cur_date,
-    cur_hour,
-    cur_minute,
-    cur_second,
-    cur_timeline,
+interface TimeBarViewProps {
+  calendarData: Array<CalendarCell>;
+  month: number;
+  year: number;
+  calendarBodyClassName: string;
+  active: boolean;
 
-    onClickDateText,
-    onClickYear,
-    onClickUp,
-    onClickDown,
-  } = props;
+  cur_year: number | string;
+  cur_month: number | string;
+  cur_day: number | string;
+  cur_date: number | string;
+  cur_hour: number | string;
+  cur_minute: number | string;
+  cur_second: number | string;
+  cur_timeline: string;
+
+  onClickDateText: () => void;
+  onClickYear: () => void;
+  onClickUp: () => void;
+  onClickDown: () => void;
+}
+
+const TimeBar = ({
+  calendarData,
+  month,
+  year,
+  calendarBodyClassName,
+  active,
+
+  cur_year,
+  cur_month,
+  cur_day,
+  cur_date,
+  cur_hour,
+  cur_minute,
+  cur_second,
+  cur_timeline,
+
+  onClickDateText,
+  onClickYear,
+  onClickUp,
+  onClickDown,
+}: TimeBarViewProps) => {
 
   return (
     <TimeBarBlock active={active}>


### PR DESCRIPTION
## 배경
- 전역 상태 경계 리팩토링 계획(`docs/plans/2026-04-07-refactor-global-state-boundary-design.md`) §10 완료 기준 중 "모든 컴포넌트 props가 interface로 타입 정의됨" 항목 충족을 위한 마무리 작업.
- 마이그레이션 대상 외 feature에 implicit any 상태의 props가 잔존하고 있었음.

## 변경 사항
- `desktop/components/IconBox.tsx`, `Window.tsx`: `DirectoryItem` 기반 props interface 추가
- `infobar/components/CommitItem.tsx`, `InfoBar.tsx`: 커밋 데이터 및 뷰 props 타입 정의
- `timebar/components/TimeBar.tsx`: 달력/시간 뷰 props interface 추가
- `hidden-icon/components/SkillIcon.tsx`, `program-info/InfoProgram.tsx`, `InfoProgram.view.tsx`: 단순 props interface 추가
- 모두 구조분해 형태(`({...}: Props)`)로 통일, 배열은 `Array<T>` 문법 사용

## 테스트
- [x] `pnpm build` 통과 (기존 사전 경고 2건 외 에러 없음)

## 영향 범위 / 주의사항
- 런타임 동작 변경 없음. 타입 선언만 추가.
- 본 PR로 §10 완료 기준 전 항목 충족 예정.