### PR TITLE
feat(shared): 에셋 매니페스트 도입으로 아이콘 키 기반 resolve 구현

### DIFF
--- a/src/data/portfolio.json
+++ b/src/data/portfolio.json
@@ -8,7 +8,7 @@
             {
                 "type": "INFO",
                 "name": "내컴퓨터",
-                "icon": "",
+                "icon": "monitor",
                 "contents": {}
             },
             {
@@ -197,15 +197,15 @@
                         "name": "MAIN_TECH",
                         "icon": "",
                         "children": [
-                            { "type": "IMAGE", "name": "React.js", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "자바스크립트", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "리덕스", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "리코일", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "노드js", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "HTML", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "CSS", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "styled-component", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "Github", "icon": "", "src": "" }
+                            { "type": "IMAGE", "name": "React.js", "icon": "react", "src": "react" },
+                            { "type": "IMAGE", "name": "자바스크립트", "icon": "javascript", "src": "javascript" },
+                            { "type": "IMAGE", "name": "리덕스", "icon": "redux", "src": "redux" },
+                            { "type": "IMAGE", "name": "리코일", "icon": "recoil", "src": "recoil" },
+                            { "type": "IMAGE", "name": "노드js", "icon": "nodejs", "src": "nodejs" },
+                            { "type": "IMAGE", "name": "HTML", "icon": "html", "src": "html" },
+                            { "type": "IMAGE", "name": "CSS", "icon": "css", "src": "css" },
+                            { "type": "IMAGE", "name": "styled-component", "icon": "styledcomponent", "src": "styledcomponent" },
+                            { "type": "IMAGE", "name": "Github", "icon": "github", "src": "github" }
                         ]
                     },
                     {
@@ -213,10 +213,10 @@
                         "name": "SUB_TECH",
                         "icon": "",
                         "children": [
-                            { "type": "IMAGE", "name": "Vue.js", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "파이썬", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "부트스트랩", "icon": "", "src": "" },
-                            { "type": "IMAGE", "name": "tailwind-css", "icon": "", "src": "" }
+                            { "type": "IMAGE", "name": "Vue.js", "icon": "vue", "src": "vue" },
+                            { "type": "IMAGE", "name": "파이썬", "icon": "python", "src": "python" },
+                            { "type": "IMAGE", "name": "부트스트랩", "icon": "bootstrap", "src": "bootstrap" },
+                            { "type": "IMAGE", "name": "tailwind-css", "icon": "tailwind_css", "src": "tailwind_css" }
                         ]
                     }
                 ]
@@ -224,7 +224,7 @@
             {
                 "type": "BROWSER",
                 "name": "구글",
-                "icon": "",
+                "icon": "chrome",
                 "url": "https://www.google.com"
             }
         ]

--- a/src/features/desktop/components/IconBox.tsx
+++ b/src/features/desktop/components/IconBox.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import defaultImg from "../../../logo.svg";
 import { css } from "@styled-system/css";
 import type { ProgramNode } from "@shared/types/program";
+import { resolveAsset } from "@shared/lib/assetManifest";
+import folderEmpty from "@images/icons/folder_empty.png";
+import imageDefault from "@images/icons/image_default.png";
+import documentDefault from "@images/icons/document_default.png";
+import monitor from "@images/icons/monitor.png";
 
 interface IconBoxProps {
     item: ProgramNode;
@@ -9,13 +13,18 @@ interface IconBoxProps {
     onDoubleClick: (item: ProgramNode) => void;
 }
 
-function nodeIcon(node: ProgramNode): string {
-    return (node as unknown as { icon?: string }).icon ?? "";
+function fallbackIcon(node: ProgramNode): string {
+    switch (node.type) {
+        case "IMAGE": return imageDefault;
+        case "DOC": return documentDefault;
+        case "INFO": return monitor;
+        default: return folderEmpty;
+    }
 }
 
 const IconBox = ({ item, onClick, onDoubleClick }: IconBoxProps) => {
     const { name } = item;
-    const icon = nodeIcon(item);
+    const icon = resolveAsset(item.icon) ?? fallbackIcon(item);
     return (
         <div
             className={iconBoxStyle}
@@ -23,7 +32,7 @@ const IconBox = ({ item, onClick, onDoubleClick }: IconBoxProps) => {
             onDoubleClick={() => onDoubleClick(item)}
         >
             <div className="iconImgBox">
-                <img src={icon ? icon : defaultImg} alt="iconImg" />
+                <img src={icon} alt="iconImg" />
             </div>
             <div className="name">{name ? name : "Icon"}</div>
         </div>

--- a/src/features/program-folder/ui/FolderGrid.tsx
+++ b/src/features/program-folder/ui/FolderGrid.tsx
@@ -3,6 +3,7 @@ import folderEmpty from "@images/icons/folder_empty.png";
 import defaultImage from "@images/icons/image_default.png";
 import { contentStyle } from "../FolderProgram.style";
 import type { ProgramId, ProgramNode } from "@shared/types/program";
+import { resolveAsset } from "@shared/lib/assetManifest";
 
 interface FolderGridProps {
     items: Array<ProgramNode>;
@@ -11,10 +12,6 @@ interface FolderGridProps {
     hasChildren: (id: ProgramId) => boolean;
     onClickItem: (id: ProgramId) => void;
     onDoubleClickItem: (item: ProgramNode) => void;
-}
-
-function nodeIcon(node: ProgramNode): string {
-    return (node as unknown as { icon?: string }).icon ?? "";
 }
 
 const FolderGrid = ({
@@ -62,7 +59,7 @@ const FolderGrid = ({
                                         />
                                     ) : (
                                         <img
-                                            src={nodeIcon(item) || defaultImage}
+                                            src={resolveAsset(item.icon) ?? defaultImage}
                                             alt={item.name}
                                         />
                                     )}

--- a/src/features/program-image/ui/ImageViewer.tsx
+++ b/src/features/program-image/ui/ImageViewer.tsx
@@ -1,7 +1,9 @@
 import collapseArrowLeft from "@images/icons/collapse-arrow-left-white.png";
 import collapseArrowRight from "@images/icons/collapse-arrow-right-white.png";
+import imageDefault from "@images/icons/image_default.png";
 import type { ProgramNode } from "@shared/types/program";
 import { contentStyle } from "../ImageProgram.style";
+import { resolveAsset } from "@shared/lib/assetManifest";
 
 interface ImageViewerProps {
     imageArr: Array<ProgramNode>;
@@ -13,7 +15,8 @@ interface ImageViewerProps {
 }
 
 function imageSrc(node: ProgramNode): string {
-    return node.type === "IMAGE" ? node.src : "";
+    if (node.type !== "IMAGE") return "";
+    return resolveAsset(node.src) ?? imageDefault;
 }
 
 const ImageViewer = ({

--- a/src/features/taskbar/ui/ProgramIcons.tsx
+++ b/src/features/taskbar/ui/ProgramIcons.tsx
@@ -5,6 +5,7 @@ import monitor from "@images/icons/monitor.png";
 import defaultDocumentImage from "@images/icons/document_default.png";
 import type { ProgramId } from "@shared/types/program";
 import type { TaskbarEntry } from "../TaskBar.types";
+import { resolveAsset } from "@shared/lib/assetManifest";
 
 interface ProgramIconsProps {
     entries: Array<TaskbarEntry>;
@@ -17,6 +18,9 @@ interface ProgramIconsProps {
 
 const renderIconImage = (entry: TaskbarEntry) => {
     const { node } = entry;
+    const custom = resolveAsset(node.icon);
+    if (custom) return <img src={custom} alt={node.name} />;
+
     switch (node.type) {
         case "IMAGE":
             return <img src={defaultImage} alt={node.name} />;
@@ -27,7 +31,7 @@ const renderIconImage = (entry: TaskbarEntry) => {
         case "INFO":
             return <img src={monitor} alt={node.name} />;
         case "BROWSER":
-            return <img src={node.icon || folderEmpty} alt={node.name} />;
+            return <img src={folderEmpty} alt={node.name} />;
         default:
             return null;
     }

--- a/src/pages/DesktopPage/resolveProgramMeta.ts
+++ b/src/pages/DesktopPage/resolveProgramMeta.ts
@@ -3,6 +3,7 @@ import defaultImage from "@images/icons/image_default.png";
 import monitor from "@images/icons/monitor.png";
 import defaultDocumentImage from "@images/icons/document_default.png";
 import type { ProgramNode } from "@shared/types/program";
+import { resolveAsset } from "@shared/lib/assetManifest";
 
 export const resolveProgramTitle = (node: ProgramNode): string => {
     if (node.type === "IMAGE") return "이미지";
@@ -10,6 +11,9 @@ export const resolveProgramTitle = (node: ProgramNode): string => {
 };
 
 export const resolveProgramIcon = (node: ProgramNode): string => {
+    const custom = resolveAsset(node.icon);
+    if (custom) return custom;
+
     switch (node.type) {
         case "IMAGE":
             return defaultImage;
@@ -18,6 +22,6 @@ export const resolveProgramIcon = (node: ProgramNode): string => {
         case "INFO":
             return monitor;
         default:
-            return node.icon || folderEmpty;
+            return folderEmpty;
     }
 };

--- a/src/shared/lib/assetManifest.ts
+++ b/src/shared/lib/assetManifest.ts
@@ -1,0 +1,46 @@
+import monitor from "@images/icons/monitor.png";
+import folderEmpty from "@images/icons/folder_empty.png";
+import folderFull from "@images/icons/folder_full.png";
+import imageDefault from "@images/icons/image_default.png";
+import documentDefault from "@images/icons/document_default.png";
+import chrome from "@images/icons/chrome.png";
+import react from "@images/icons/react.png";
+import javascript from "@images/icons/javascript.png";
+import redux from "@images/icons/redux.png";
+import recoil from "@images/icons/recoil.png";
+import nodejs from "@images/icons/nodejs.png";
+import html from "@images/icons/html.png";
+import css from "@images/icons/css.png";
+import styledcomponent from "@images/icons/styledcomponent.png";
+import github from "@images/icons/github.png";
+import vue from "@images/icons/vue.png";
+import python from "@images/icons/python.png";
+import bootstrap from "@images/icons/bootstrap.png";
+import tailwindCss from "@images/icons/tailwind-css.png";
+import vuetify from "@images/icons/vuetify.png";
+
+const assetManifest: Record<string, string> = {
+    monitor,
+    folder_empty: folderEmpty,
+    folder_full: folderFull,
+    image_default: imageDefault,
+    document_default: documentDefault,
+    chrome,
+    react,
+    javascript,
+    redux,
+    recoil,
+    nodejs,
+    html,
+    css,
+    styledcomponent,
+    github,
+    vue,
+    python,
+    bootstrap,
+    tailwind_css: tailwindCss,
+    vuetify,
+};
+
+export const resolveAsset = (key: string): string | undefined =>
+    assetManifest[key];

--- a/src/shared/lib/file-system/selectors/selectStatusBarViewModel.ts
+++ b/src/shared/lib/file-system/selectors/selectStatusBarViewModel.ts
@@ -1,4 +1,5 @@
 import type { FileSystemState, ProgramId, ProgramNode } from "@shared/types/program";
+import { resolveAsset } from "@shared/lib/assetManifest";
 
 export interface StatusBarViewItem {
     name: string;
@@ -50,7 +51,7 @@ function childrenOf(
         .filter((n): n is ProgramNode => !!n)
         .map((n) => ({
             name: n.name,
-            icon: (n as unknown as { icon?: string }).icon ?? "",
+            icon: resolveAsset(n.icon) ?? "",
             parentName,
             parentId,
             type: n.type,


### PR DESCRIPTION
## 배경
- `portfolio.json`의 아이콘이 문자열 키로만 저장되어 있어 webpack import된 실제 이미지로 변환되지 않아 아이콘이 깨지는 문제가 있었다.
- 중앙 매니페스트를 도입하여 키→이미지 매핑을 한 곳에서 관리하고, 각 컴포넌트가 `resolveAsset(key)`로 이미지를 얻도록 한다.

## 변경 사항
- `src/shared/lib/assetManifest.ts`: 20개 아이콘 키→import 매핑 + `resolveAsset()` 함수 신설
- `src/data/portfolio.json`: INFO/BROWSER/IMAGE 노드의 icon/src 필드에 매니페스트 키 채움
- `src/pages/DesktopPage/resolveProgramMeta.ts`: `resolveAsset` 우선 적용, fallback은 type별 기본값
- `src/features/desktop/components/IconBox.tsx`: `nodeIcon` 캐스트 제거, `resolveAsset` + type별 `fallbackIcon` 도입
- `src/features/program-folder/ui/FolderGrid.tsx`: `nodeIcon` 캐스트 제거, `resolveAsset` 적용
- `src/features/taskbar/ui/ProgramIcons.tsx`: `resolveAsset` 우선 적용
- `src/features/program-image/ui/ImageViewer.tsx`: IMAGE `src` 필드를 `resolveAsset`으로 resolve

## 동작 방식
- `assetManifest.ts`가 빌드 타임에 모든 아이콘을 webpack import하여 `Record<string, string>` 매핑을 구성한다.
- 각 컴포넌트는 `resolveAsset(node.icon)`으로 먼저 시도하고, undefined이면 type별 fallback 이미지를 사용한다.
- Feature 레이어에서 `@shared/lib/assetManifest`를 직접 import한다 (store가 아니므로 3-레이어 규칙 위반 아님).

## 테스트
- [x] `pnpm exec tsc --noEmit` — 새 타입 에러 없음
- [x] `pnpm test --watchAll=false --passWithNoTests` — 통과
- [ ] 수동 스모크 테스트: 바탕화면/폴더/작업표시줄/이미지뷰어 아이콘 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)