### PR TITLE
refactor(style): 스크롤바 스타일 글로벌 통합

### DIFF
--- a/src/features/infobar/components/InfoBar.style.ts
+++ b/src/features/infobar/components/InfoBar.style.ts
@@ -25,7 +25,7 @@ const infoBarRecipe = cva({
     },
 
     "& .commitArea": {
-      overflow: "scroll",
+      overflow: "auto",
     },
 
     "& .displayLightArea": {

--- a/src/features/program-doc/DOCProgram.style.ts
+++ b/src/features/program-doc/DOCProgram.style.ts
@@ -19,7 +19,7 @@ export const docProgramContentStyle = css({
         minHeight: "200px",
         backgroundColor: "surface.content",
         display: "inline-block",
-        overflow: "scroll",
+        overflow: "auto",
 
         flexGrow: 1,
         flexBasis: "program.default",
@@ -54,7 +54,7 @@ export const docProgramContentStyle = css({
     "& .doc_contentsArea": {
         flex: 1,
 
-        overflow: "scroll",
+        overflow: "auto",
         height: "100%",
         width: "100%",
         flexGrow: 1,

--- a/src/features/statusbar/components/StatusBar.style.ts
+++ b/src/features/statusbar/components/StatusBar.style.ts
@@ -96,14 +96,6 @@ const statusBarRecipe = cva({
       animationName: "show_from_bottom",
     },
 
-    "& .rightArea::-webkit-scrollbar, & .centerArea::-webkit-scrollbar": {
-      width: "2px",
-    },
-
-    "& .rightArea::-webkit-scrollbar-thumb, & .centerArea::-webkit-scrollbar-thumb":
-      {
-        backgroundColor: "shell.border",
-      },
   },
   variants: {
     active: {

--- a/src/features/statusbar/components/StatusBar.style.ts
+++ b/src/features/statusbar/components/StatusBar.style.ts
@@ -61,12 +61,12 @@ const statusBarRecipe = cva({
     "& .centerArea": {
       backgroundColor: "transparent",
       width: "270px",
-      overflowY: "scroll",
+      overflowY: "auto",
     },
 
     "& .rightArea": {
       width: "330px",
-      overflowY: "scroll",
+      overflowY: "auto",
     },
 
     "& .rightArea_title": {

--- a/src/features/window-shell/ProgramComponent.style.ts
+++ b/src/features/window-shell/ProgramComponent.style.ts
@@ -155,7 +155,7 @@ const programComponentRecipe = cva({
     "& .contentsArea_Cover": {
       width: "100%",
       height: "100%",
-      overflow: "scroll",
+      overflow: "auto",
       position: "relative",
     },
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,30 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  /* Global custom scrollbar — Windows style, cross-browser */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--colors-shell-border) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: var(--colors-shell-border);
+    border-radius: 4px;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--colors-surface-text-muted);
+  }
+
   h1 {
     font-size: 2em;
     font-weight: bold;


### PR DESCRIPTION
## 배경
- 각 컴포넌트마다 `overflow: scroll`과 개별 `::-webkit-scrollbar` 스타일이 산재되어 있었다.
- 콘텐츠가 넘치지 않아도 스크롤바가 항상 표시되는 문제가 있었고, 스크롤바 스타일이 컴포넌트별로 일관되지 않았다.

## 변경 사항
- **overflow 속성 일괄 변경** (`scroll` → `auto`): InfoBar, DOCProgram, StatusBar, ProgramComponent 4개 파일
- **StatusBar 개별 scrollbar 스타일 제거**: `.rightArea`, `.centerArea`에 한정된 `::-webkit-scrollbar` 선언 삭제
- **index.css 글로벌 스크롤바 스타일 추가**: `scrollbar-width: thin`(표준) + `::-webkit-scrollbar` 계열(Chrome/Safari) 전역 적용, hover 시 thumb 색상 변경

## 테스트
- [ ] 수동 확인: 각 영역(InfoBar, DOCProgram, StatusBar, ProgramComponent)에서 스크롤바 표시/숨김 동작
- [ ] 수동 확인: 스크롤바 hover 시 색상 변경
- [ ] Firefox/Chrome 크로스 브라우저 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)