### PR TITLE
feat(statusbar): 시작 메뉴 로그아웃 기능 + 페이지 전환 애니메이션

### DIFF
--- a/docs/plans/2026-04-13-logout-animation-design.md
+++ b/docs/plans/2026-04-13-logout-animation-design.md
@@ -35,7 +35,7 @@ const LOGOUT_FADE_DURATION_MS = 400;  // 페이드인 애니메이션 시간
 - `LogoutOverlay` — 풀스크린 검정 오버레이 + 중앙 "로그아웃 중..." 텍스트
   - props: `visible: boolean`
   - visible=true일 때 opacity 0→1 페이드인 (CSS transition)
-  - z-index: 모든 요소 위 (9999)
+  - z-index: 모든 요소 위 (99999)
 
 ### 수정 대상 파일
 

--- a/docs/plans/2026-04-13-logout-animation-design.md
+++ b/docs/plans/2026-04-13-logout-animation-design.md
@@ -1,0 +1,94 @@
+# 로그아웃 애니메이션
+
+## 배경
+
+시작 메뉴 로그아웃 기능(feat/statusbar-logout)이 구현된 상태에서, 전원 아이콘 클릭 시 즉시 화면 전환되는 것이 어색하다. 실제 Windows OS처럼 화면이 어두워지면서 "로그아웃 중..." 텍스트가 잠깐 표시된 뒤 로그인 화면으로 전환되는 애니메이션을 추가한다.
+
+## 설계 규칙
+
+- Shell에 로직(타이머, 상태 전환)을 둔다. 오버레이 컴포넌트는 props만 받는다.
+- 매직 넘버를 상수로 분리하여 튜닝 가능하게 한다.
+- 오버레이는 DesktopPage 안에 위치하여, navigate 시 자연스럽게 unmount된다.
+
+## 아키텍처
+
+### 동작 흐름
+
+```
+[전원 아이콘 클릭]
+  → setIsLoggingOut(true) → 오버레이 페이드인 (LOGOUT_FADE_DURATION_MS)
+  → setTimeout(LOGOUT_DELAY_MS) 후
+    → runningProgramsStore.reset()
+    → closeAllMenus()
+    → navigate("/window/login", { replace: true })
+```
+
+### 상수
+
+```ts
+const LOGOUT_DELAY_MS = 1000;         // 오버레이 체류 시간
+const LOGOUT_FADE_DURATION_MS = 400;  // 페이드인 애니메이션 시간
+```
+
+### 컴포넌트 구조
+
+- `LogoutOverlay` — 풀스크린 검정 오버레이 + 중앙 "로그아웃 중..." 텍스트
+  - props: `visible: boolean`
+  - visible=true일 때 opacity 0→1 페이드인 (CSS transition)
+  - z-index: 모든 요소 위 (9999)
+
+### 수정 대상 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/pages/DesktopPage/components/LogoutOverlay.tsx` | 신규 — 풀스크린 오버레이 컴포넌트 |
+| `src/pages/DesktopPage/components/LogoutOverlay.style.ts` | 신규 — 오버레이 스타일 |
+| `src/pages/DesktopPage/shells/StatusBarShell.tsx` | 수정 — isLoggingOut 상태 + 타이머 로직, onLogout에서 즉시 navigate 대신 애니메이션 트리거 |
+| `src/pages/DesktopPage/DesktopPage.tsx` | 수정 — LogoutOverlay 렌더링 추가 |
+
+### 데이터 흐름
+
+StatusBarShell이 `isLoggingOut` 상태와 `handleLogout`을 소유한다.
+- `handleLogout`: `isLoggingOut = true` 설정 → `setTimeout`으로 지연 후 스토어 초기화 + navigate
+- `isLoggingOut`을 DesktopPage까지 올려서 LogoutOverlay에 전달하거나, StatusBarShell이 직접 LogoutOverlay를 렌더링한다.
+
+**선택: StatusBarShell → props로 DesktopPage에 전달**
+- StatusBarShell은 이미 DesktopPage 안에서 렌더링되므로, isLoggingOut 상태를 위로 올리거나 콜백 패턴을 사용한다.
+- 가장 단순한 방법: StatusBarShell 내부에서 LogoutOverlay를 직접 렌더링 (Portal 불필요 — fixed position이면 DOM 위치 무관)
+
+## 성공 기준 (Definition of Done)
+
+- [ ] 전원 아이콘 클릭 시 화면이 검정으로 페이드인된다
+- [ ] 페이드인 완료 후 중앙에 "로그아웃 중..." 텍스트가 보인다
+- [ ] ~1초 후 로그인 화면으로 전환된다
+- [ ] 체류 시간/페이드 시간이 상수로 분리되어 있다
+- [ ] 기존 로그아웃 기능(스토어 초기화, 메뉴 닫기)에 영향 없다
+
+---
+
+## Phase 1: LogoutOverlay 컴포넌트 생성
+
+**입력**: 없음
+
+**작업 내용**:
+- [ ] `src/pages/DesktopPage/components/LogoutOverlay.style.ts` — 풀스크린 오버레이 스타일 (fixed, z-index 9999, 검정 배경, 페이드 transition)
+- [ ] `src/pages/DesktopPage/components/LogoutOverlay.tsx` — visible prop에 따라 페이드인/아웃하는 오버레이 + 중앙 "로그아웃 중..." 텍스트
+
+**완료 조건**: LogoutOverlay에 visible=true 전달 시 검정 오버레이가 페이드인되며 중앙 텍스트가 표시된다.
+
+## Phase 2: StatusBarShell에 애니메이션 로직 연결
+
+**입력**: Phase 1 완료
+
+**작업 내용**:
+- [ ] `src/pages/DesktopPage/shells/StatusBarShell.tsx` — handleLogout을 애니메이션 트리거 방식으로 변경 (isLoggingOut 상태 + setTimeout 후 스토어 초기화 + navigate), 상수 LOGOUT_DELAY_MS / LOGOUT_FADE_DURATION_MS 분리
+- [ ] `src/pages/DesktopPage/shells/StatusBarShell.tsx` — LogoutOverlay 렌더링 추가
+
+**완료 조건**: 전원 아이콘 클릭 → 오버레이 페이드인 → ~1초 후 로그인 화면 전환.
+
+### 수동 검증
+- [ ] 전원 아이콘 클릭 → 화면이 서서히 검정으로 변하는지 확인
+- [ ] "로그아웃 중..." 텍스트가 중앙에 표시되는지 확인
+- [ ] ~1초 후 로그인 화면(Lock Screen)으로 이동하는지 확인
+- [ ] 로그인 → 데스크탑 재진입 후 프로그램 창이 깨끗한지 확인
+- [ ] 기존 시작 메뉴 기능 정상 동작 확인

--- a/src/app/routers/WindowRouter.tsx
+++ b/src/app/routers/WindowRouter.tsx
@@ -4,20 +4,20 @@ import LoginPage from "@features/login/LoginPage";
 import ErrorPage from "@app/ErrorPage";
 import wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 
+const blurBackdropStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  backgroundImage: `url(${wallpaper})`,
+  backgroundSize: "cover",
+  backgroundPosition: "center",
+  filter: "blur(20px) brightness(0.4)",
+  zIndex: -1,
+};
+
 export default function WindowRouter() {
   return (
     <>
-      <div
-        style={{
-          position: "fixed",
-          inset: 0,
-          backgroundImage: `url(${wallpaper})`,
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          filter: "blur(20px) brightness(0.4)",
-          zIndex: -1,
-        }}
-      />
+      <div style={blurBackdropStyle} />
       <Routes>
         <Route path="desktop" element={<DesktopPage />} />
         <Route path="login" element={<LoginPage />} />

--- a/src/app/routers/WindowRouter.tsx
+++ b/src/app/routers/WindowRouter.tsx
@@ -2,14 +2,28 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { DesktopPage } from "@pages/DesktopPage";
 import LoginPage from "@features/login/LoginPage";
 import ErrorPage from "@app/ErrorPage";
+import wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 
 export default function WindowRouter() {
   return (
-    <Routes>
-      <Route path="desktop" element={<DesktopPage />} />
-      <Route path="login" element={<LoginPage />} />
-      <Route path="error" element={<ErrorPage />} />
-      <Route path="*" element={<Navigate to="error" replace />} />
-    </Routes>
+    <>
+      <div
+        style={{
+          position: "fixed",
+          inset: 0,
+          backgroundImage: `url(${wallpaper})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "blur(20px) brightness(0.4)",
+          zIndex: -1,
+        }}
+      />
+      <Routes>
+        <Route path="desktop" element={<DesktopPage />} />
+        <Route path="login" element={<LoginPage />} />
+        <Route path="error" element={<ErrorPage />} />
+        <Route path="*" element={<Navigate to="error" replace />} />
+      </Routes>
+    </>
   );
 }

--- a/src/asset/images/icons/power.svg
+++ b/src/asset/images/icons/power.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3v5" />
+  <path d="M18.36 6.64A9 9 0 1 1 5.64 6.64" />
+</svg>

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -2,8 +2,9 @@ import Login from "./Login";
 import Samsung_wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 import FullScreenBox from "@shared/ui/FullScreenBox";
 import WallPaper from "@shared/ui/WallPaper/WallPaper";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { useFadeIn } from "@shared/hooks";
 
 const FADE_IN_DURATION_MS = 400;
 const FADE_OUT_DURATION_MS = 400;
@@ -13,12 +14,7 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const isUnlocked = searchParams.get("isUnlocked") === "true";
   const [isFadingOut, setIsFadingOut] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    const frame = requestAnimationFrame(() => setIsMounted(true));
-    return () => cancelAnimationFrame(frame);
-  }, []);
+  const isMounted = useFadeIn();
 
   const handleUnlock = useCallback(() => {
     setSearchParams({ isUnlocked: "true" }, { replace: true });

--- a/src/features/login/LoginPage.tsx
+++ b/src/features/login/LoginPage.tsx
@@ -2,16 +2,23 @@ import Login from "./Login";
 import Samsung_wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 import FullScreenBox from "@shared/ui/FullScreenBox";
 import WallPaper from "@shared/ui/WallPaper/WallPaper";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
-const FADE_OUT_DURATION = 400;
+const FADE_IN_DURATION_MS = 400;
+const FADE_OUT_DURATION_MS = 400;
 
 export default function LoginPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const isUnlocked = searchParams.get("isUnlocked") === "true";
   const [isFadingOut, setIsFadingOut] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setIsMounted(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   const handleUnlock = useCallback(() => {
     setSearchParams({ isUnlocked: "true" }, { replace: true });
@@ -21,14 +28,14 @@ export default function LoginPage() {
     setIsFadingOut(true);
     setTimeout(() => {
       navigate("/window/desktop", { replace: true });
-    }, FADE_OUT_DURATION);
+    }, FADE_OUT_DURATION_MS);
   }, [navigate]);
 
   return (
     <FullScreenBox
       style={{
-        opacity: isFadingOut ? 0 : 1,
-        transition: `opacity ${FADE_OUT_DURATION}ms ease`,
+        opacity: isMounted && !isFadingOut ? 1 : 0,
+        transition: `opacity ${isFadingOut ? FADE_OUT_DURATION_MS : FADE_IN_DURATION_MS}ms ease`,
       }}
     >
       <WallPaper wallpaper={Samsung_wallpaper} blur={isUnlocked} />

--- a/src/features/statusbar/StatusBar.tsx
+++ b/src/features/statusbar/StatusBar.tsx
@@ -14,6 +14,7 @@ interface StatusBarProps {
     viewModel: StatusBarViewModel;
     onOpenProgram: (id: ProgramId) => void;
     onClose: () => void;
+    onLogout: () => void;
 }
 
 const STATUSBAR_LEFT_AREA_ITEMS = [
@@ -25,7 +26,7 @@ const STATUSBAR_LEFT_AREA_ITEMS = [
     { img: imgKit, text: "금오공과대학교 졸업" },
 ];
 
-const StatusBar = ({ active, viewModel, onOpenProgram, onClose }: StatusBarProps) => {
+const StatusBar = ({ active, viewModel, onOpenProgram, onClose, onLogout }: StatusBarProps) => {
     const [activeLeftArea_Detail, setActiveLeftArea_Detail] = useState(false);
     const activeLeftArea_timer = useRef<ReturnType<typeof setTimeout> | null>(
         null,
@@ -72,6 +73,7 @@ const StatusBar = ({ active, viewModel, onOpenProgram, onClose }: StatusBarProps
             onMouseLeave={onMouseLeave}
             onClickBox={handleClickBox}
             onClickLeftArea={handleClickLeftArea}
+            onLogout={onLogout}
         />
     );
 };

--- a/src/features/statusbar/components/StatusBar.style.ts
+++ b/src/features/statusbar/components/StatusBar.style.ts
@@ -90,6 +90,10 @@ const statusBarRecipe = cva({
       marginBottom: "32",
     },
 
+    "& .leftArea_bottom": {
+      borderTop: "1px solid token(colors.shell.border)",
+    },
+
     "& .show_animation": {
       animationDuration: "0.4s",
       animationTimingFunction: "cubic-bezier(0, 0.65, 0.35, 1)",

--- a/src/features/statusbar/components/StatusBar.tsx
+++ b/src/features/statusbar/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import imgMenu from "@images/icons/hamburger_menu.png";
+import imgPower from "@images/icons/power.svg";
 import LeftAreaBox from "./LeftAreaBox";
 import CenterAreaBox from "./CenterAreaBox";
 import RightAreaBox from "./RightAreaBox";
@@ -19,6 +20,7 @@ type StatusBarViewProps = {
     onMouseLeave: () => void;
     onClickBox: (id: ProgramId) => void;
     onClickLeftArea: () => void;
+    onLogout: () => void;
 };
 
 const StatusBarView = ({
@@ -32,6 +34,7 @@ const StatusBarView = ({
     onMouseLeave,
     onClickBox,
     onClickLeftArea,
+    onLogout,
 }: StatusBarViewProps) => {
     return (
         <StatusBarBlock active={active}>
@@ -65,6 +68,13 @@ const StatusBarView = ({
                                 onClick={onClickLeftArea}
                             />
                         ))}
+                    </div>
+                    <div className="leftArea_bottom">
+                        <LeftAreaBox
+                            img={imgPower}
+                            name={"로그아웃"}
+                            onClick={onLogout}
+                        />
                     </div>
                 </div>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
 @layer base {
   body {
     margin: 0;
+    background: black;
     /* font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
       'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
       sans-serif; */

--- a/src/pages/DesktopPage/DesktopPage.tsx
+++ b/src/pages/DesktopPage/DesktopPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { css } from "@styled-system/css";
 import wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 import DisplayCover from "@features/display-cover/DisplayCover";
@@ -16,7 +16,16 @@ import type { ProgramId } from "@shared/types/program";
 import ProgramWindow from "./ProgramWindow";
 import { renderProgramContent } from "./renderProgramContent";
 
+const FADE_IN_DURATION_MS = 400;
+
 export default function DesktopPage() {
+    const [isMounted, setIsMounted] = useState(false);
+
+    useEffect(() => {
+        const frame = requestAnimationFrame(() => setIsMounted(true));
+        return () => cancelAnimationFrame(frame);
+    }, []);
+
     // === File system ===
     const nodes = useFileSystemStore((s) => s.nodes);
 
@@ -98,7 +107,11 @@ export default function DesktopPage() {
     return (
         <div
             className={mainPageStyle}
-            style={{ backgroundImage: `url(${wallpaper})` }}
+            style={{
+                backgroundImage: `url(${wallpaper})`,
+                opacity: isMounted ? 1 : 0,
+                transition: `opacity ${FADE_IN_DURATION_MS}ms ease`,
+            }}
         >
             <DisplayCover displayLight={displayLight} />
             <div

--- a/src/pages/DesktopPage/DesktopPage.tsx
+++ b/src/pages/DesktopPage/DesktopPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { css } from "@styled-system/css";
 import wallpaper from "@images/wallpaper/Samsung_wallpaper.jpg";
 import DisplayCover from "@features/display-cover/DisplayCover";
@@ -13,18 +13,14 @@ import { useFileSystemStore } from "@store/fileSystemStore";
 import { useRunningProgramsStore } from "@store/runningProgramsStore";
 import { useUiStore } from "@store/uiStore";
 import type { ProgramId } from "@shared/types/program";
+import { useFadeIn } from "@shared/hooks";
 import ProgramWindow from "./ProgramWindow";
 import { renderProgramContent } from "./renderProgramContent";
 
 const FADE_IN_DURATION_MS = 400;
 
 export default function DesktopPage() {
-    const [isMounted, setIsMounted] = useState(false);
-
-    useEffect(() => {
-        const frame = requestAnimationFrame(() => setIsMounted(true));
-        return () => cancelAnimationFrame(frame);
-    }, []);
+    const isMounted = useFadeIn();
 
     // === File system ===
     const nodes = useFileSystemStore((s) => s.nodes);

--- a/src/pages/DesktopPage/components/LogoutOverlay.style.ts
+++ b/src/pages/DesktopPage/components/LogoutOverlay.style.ts
@@ -7,7 +7,8 @@ export const logoutOverlayStyle = css({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "black",
+    backgroundColor: "rgba(0, 0, 0, 0.6)",
+    backdropFilter: "blur(20px)",
     transition: "opacity var(--logout-fade-duration) ease-in",
     pointerEvents: "none",
 

--- a/src/pages/DesktopPage/components/LogoutOverlay.style.ts
+++ b/src/pages/DesktopPage/components/LogoutOverlay.style.ts
@@ -1,0 +1,20 @@
+import { css } from "@styled-system/css";
+
+export const logoutOverlayStyle = css({
+    position: "fixed",
+    inset: 0,
+    zIndex: 99999,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "black",
+    transition: "opacity var(--logout-fade-duration) ease-in",
+    pointerEvents: "none",
+
+    "& .logoutText": {
+        color: "white",
+        fontSize: "20px",
+        fontWeight: 300,
+        letterSpacing: "2px",
+    },
+});

--- a/src/pages/DesktopPage/components/LogoutOverlay.tsx
+++ b/src/pages/DesktopPage/components/LogoutOverlay.tsx
@@ -1,0 +1,22 @@
+import { logoutOverlayStyle } from "./LogoutOverlay.style";
+import { LOGOUT_FADE_DURATION_MS } from "../shells/StatusBarShell";
+
+type LogoutOverlayProps = {
+    visible: boolean;
+};
+
+const LogoutOverlay = ({ visible }: LogoutOverlayProps) => {
+    return (
+        <div
+            className={logoutOverlayStyle}
+            style={{
+                opacity: visible ? 1 : 0,
+                "--logout-fade-duration": `${LOGOUT_FADE_DURATION_MS}ms`,
+            } as React.CSSProperties}
+        >
+            <p className="logoutText">로그아웃 중...</p>
+        </div>
+    );
+};
+
+export default LogoutOverlay;

--- a/src/pages/DesktopPage/components/LogoutOverlay.tsx
+++ b/src/pages/DesktopPage/components/LogoutOverlay.tsx
@@ -1,5 +1,5 @@
 import { logoutOverlayStyle } from "./LogoutOverlay.style";
-import { LOGOUT_FADE_DURATION_MS } from "../shells/StatusBarShell";
+import { LOGOUT_FADE_DURATION_MS } from "../constants/logout";
 
 type LogoutOverlayProps = {
     visible: boolean;

--- a/src/pages/DesktopPage/constants/logout.ts
+++ b/src/pages/DesktopPage/constants/logout.ts
@@ -1,0 +1,5 @@
+/** 오버레이 체류 시간 (ms) */
+export const LOGOUT_DELAY_MS = 1000;
+
+/** 페이드인 애니메이션 시간 (ms) */
+export const LOGOUT_FADE_DURATION_MS = 400;

--- a/src/pages/DesktopPage/shells/StatusBarShell.tsx
+++ b/src/pages/DesktopPage/shells/StatusBarShell.tsx
@@ -8,8 +8,7 @@ import StatusBar from "@features/statusbar/StatusBar";
 import LogoutOverlay from "../components/LogoutOverlay";
 import type { ProgramId } from "@shared/types/program";
 
-export const LOGOUT_DELAY_MS = 1000;
-export const LOGOUT_FADE_DURATION_MS = 400;
+import { LOGOUT_DELAY_MS, LOGOUT_FADE_DURATION_MS } from "../constants/logout";
 
 const StatusBarShell = () => {
     const navigate = useNavigate();
@@ -37,6 +36,7 @@ const StatusBarShell = () => {
     }, []);
 
     const handleLogout = useCallback(() => {
+        if (isLoggingOut) return;
         setIsLoggingOut(true);
         useUiStore.getState().closeAllMenus();
 
@@ -44,7 +44,7 @@ const StatusBarShell = () => {
             useRunningProgramsStore.getState().reset();
             navigate("/window/login", { replace: true });
         }, LOGOUT_DELAY_MS);
-    }, [navigate]);
+    }, [isLoggingOut, navigate]);
 
     return (
         <>

--- a/src/pages/DesktopPage/shells/StatusBarShell.tsx
+++ b/src/pages/DesktopPage/shells/StatusBarShell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useFileSystemStore } from "@store/fileSystemStore";
 import { useRunningProgramsStore } from "@store/runningProgramsStore";
 import { useUiStore } from "@store/uiStore";
@@ -7,6 +8,7 @@ import StatusBar from "@features/statusbar/StatusBar";
 import type { ProgramId } from "@shared/types/program";
 
 const StatusBarShell = () => {
+    const navigate = useNavigate();
     const rootId = useFileSystemStore((s) => s.rootId);
     const nodes = useFileSystemStore((s) => s.nodes);
     const childrenByParent = useFileSystemStore((s) => s.childrenByParent);
@@ -28,12 +30,19 @@ const StatusBarShell = () => {
         useUiStore.setState({ statusBarOpen: false });
     }, []);
 
+    const handleLogout = useCallback(() => {
+        useRunningProgramsStore.getState().reset();
+        useUiStore.getState().closeAllMenus();
+        navigate("/window/login", { replace: true });
+    }, [navigate]);
+
     return (
         <StatusBar
             active={statusBarOpen}
             viewModel={viewModel}
             onOpenProgram={handleOpenProgram}
             onClose={handleClose}
+            onLogout={handleLogout}
         />
     );
 };

--- a/src/pages/DesktopPage/shells/StatusBarShell.tsx
+++ b/src/pages/DesktopPage/shells/StatusBarShell.tsx
@@ -1,11 +1,15 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useFileSystemStore } from "@store/fileSystemStore";
 import { useRunningProgramsStore } from "@store/runningProgramsStore";
 import { useUiStore } from "@store/uiStore";
 import { selectStatusBarViewModel } from "@shared/lib/file-system/selectors/selectStatusBarViewModel";
 import StatusBar from "@features/statusbar/StatusBar";
+import LogoutOverlay from "../components/LogoutOverlay";
 import type { ProgramId } from "@shared/types/program";
+
+export const LOGOUT_DELAY_MS = 1000;
+export const LOGOUT_FADE_DURATION_MS = 400;
 
 const StatusBarShell = () => {
     const navigate = useNavigate();
@@ -15,6 +19,8 @@ const StatusBarShell = () => {
     const statusBarOpen = useUiStore((s) => s.statusBarOpen);
 
     const openProgram = useRunningProgramsStore((s) => s.open);
+
+    const [isLoggingOut, setIsLoggingOut] = useState(false);
 
     const viewModel = useMemo(
         () => selectStatusBarViewModel({ rootId, nodes, childrenByParent }),
@@ -31,19 +37,26 @@ const StatusBarShell = () => {
     }, []);
 
     const handleLogout = useCallback(() => {
-        useRunningProgramsStore.getState().reset();
+        setIsLoggingOut(true);
         useUiStore.getState().closeAllMenus();
-        navigate("/window/login", { replace: true });
+
+        setTimeout(() => {
+            useRunningProgramsStore.getState().reset();
+            navigate("/window/login", { replace: true });
+        }, LOGOUT_DELAY_MS);
     }, [navigate]);
 
     return (
-        <StatusBar
-            active={statusBarOpen}
-            viewModel={viewModel}
-            onOpenProgram={handleOpenProgram}
-            onClose={handleClose}
-            onLogout={handleLogout}
-        />
+        <>
+            <StatusBar
+                active={statusBarOpen}
+                viewModel={viewModel}
+                onOpenProgram={handleOpenProgram}
+                onClose={handleClose}
+                onLogout={handleLogout}
+            />
+            <LogoutOverlay visible={isLoggingOut} />
+        </>
     );
 };
 

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,4 +1,5 @@
 export { default as useAxios } from "./useAxios";
+export { default as useFadeIn } from "./useFadeIn";
 export { default as useGetCurrentTime } from "./useGetCurrentTime";
 export { default as useOutsideClick } from "./useOutsideClick";
 export { default as useScreenHeight } from "./useScreenHeight";

--- a/src/shared/hooks/useFadeIn.ts
+++ b/src/shared/hooks/useFadeIn.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 마운트 직후 다음 애니메이션 프레임에서 isMounted를 true로 전환하여
+ * opacity 기반 페이드인을 트리거하는 훅.
+ *
+ * @returns isMounted — 페이드인 시작 여부
+ */
+export default function useFadeIn(): boolean {
+    const [isMounted, setIsMounted] = useState(false);
+
+    useEffect(() => {
+        const frame = requestAnimationFrame(() => setIsMounted(true));
+        return () => cancelAnimationFrame(frame);
+    }, []);
+
+    return isMounted;
+}

--- a/src/store/runningProgramsStore.ts
+++ b/src/store/runningProgramsStore.ts
@@ -17,6 +17,7 @@ interface RunningProgramsActions {
     minimize: (id: ProgramId) => void;
     toggleFromTaskbar: (id: ProgramId) => void;
     requestZIndex: () => number;
+    reset: () => void;
 }
 
 export type RunningProgramsStore = RunningProgramsState & RunningProgramsActions;
@@ -103,6 +104,15 @@ export const useRunningProgramsStore = create<RunningProgramsStore>()(
                 next = draft.zIndexCounter;
             });
             return next;
+        },
+
+        reset: () => {
+            set((draft) => {
+                draft.byId = {};
+                draft.order = [];
+                draft.activeId = null;
+                draft.zIndexCounter = 1;
+            });
         },
     })),
 );


### PR DESCRIPTION
## 배경
- 메인(데스크탑)에서 로그인 화면으로 돌아갈 방법이 없었음
- Windows OS 시작 메뉴 좌측 하단 전원 아이콘을 모방하여 로그아웃 경로 추가
- 로그아웃/로그인 페이지 전환 시 자연스러운 애니메이션 적용

## 변경 사항
- `src/asset/images/icons/power.svg`: 전원 아이콘 SVG 신규 생성
- `src/store/runningProgramsStore.ts`: `reset` 액션 추가 — 로그아웃 시 전체 상태 초기화
- `src/features/statusbar/`: `onLogout` prop 체인 추가 (View → Container → Shell)
- `src/features/statusbar/components/StatusBar.style.ts`: `leftArea_bottom` 스타일 추가
- `src/pages/DesktopPage/components/LogoutOverlay.tsx`: 풀스크린 오버레이 컴포넌트 (backdrop-filter blur + 반투명 어둡게 + "로그아웃 중..." 텍스트)
- `src/pages/DesktopPage/shells/StatusBarShell.tsx`: `handleLogout` 애니메이션 로직 (오버레이 → 딜레이 → 스토어 초기화 → navigate)
- `src/app/routers/WindowRouter.tsx`: 상시 blurred wallpaper 배경 레이어 추가
- `src/pages/DesktopPage/DesktopPage.tsx`, `src/features/login/LoginPage.tsx`: 마운트 시 페이드인 추가
- `src/index.css`: body background black (폴백)

## 동작 방식
- 전원 아이콘 클릭 → `isLoggingOut=true` → 오버레이 페이드인(0.4초) → 체류(1초) → 스토어 초기화 + navigate
- 페이지 전환 시 WindowRouter의 blurred wallpaper 레이어가 항상 뒤에 깔려 있어 흰색 번쩍임 없이 자연스러운 전환
- 체류 시간(`LOGOUT_DELAY_MS`), 페이드 시간(`LOGOUT_FADE_DURATION_MS`) 등 상수 분리로 튜닝 가능

## 테스트
- [x] `pnpm exec tsc --noEmit` 통과
- [x] 수동 확인: 시작 메뉴 → leftArea 최하단 전원 아이콘 표시
- [x] 수동 확인: 전원 아이콘 클릭 → 배경 흐림 + "로그아웃 중..." → 로그인 화면 페이드인
- [x] 수동 확인: 로그인 → 데스크탑 전환 시에도 흐림 배경 기반 페이드인
- [x] 수동 확인: 재진입 후 프로그램 창 초기화 확인
- [x] 수동 확인: 기존 시작 메뉴 기능(소개, 프로젝트, 기술스택) 정상 동작