### PR TITLE
feat(dx): 개발 서버 탭 제목에 git 브랜치명 표시

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,31 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { fileURLToPath } from "url";
+import { execSync } from "child_process";
+import type { Plugin } from "vite";
+
+function devBranchTitlePlugin(): Plugin {
+  return {
+    name: "dev-branch-title",
+    apply: "serve",
+    transformIndexHtml(html) {
+      try {
+        const branch = execSync("git rev-parse --abbrev-ref HEAD", {
+          encoding: "utf-8",
+        }).trim();
+        return html.replace(
+          /<title>(.*?)<\/title>/,
+          `<title>[${branch}] $1</title>`,
+        );
+      } catch {
+        return html;
+      }
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), devBranchTitlePlugin()],
   resolve: {
     tsconfigPaths: true,
   },


### PR DESCRIPTION
## 배경
- 워크트리별로 개발 서버를 동시에 띄우면 브라우저 탭 제목이 모두 동일해 어떤 서버가 어떤 브랜치인지 구분 불가
- 탭 제목에 현재 브랜치명을 표시해 즉시 식별 가능하도록 개선

## 변경 사항
- `vite.config.ts`: `devBranchTitlePlugin` Vite 플러그인 추가
  - `apply: "serve"` — 개발 서버에서만 동작, 프로덕션 빌드 영향 없음
  - `transformIndexHtml`에서 `git rev-parse --abbrev-ref HEAD`로 브랜치명 읽어 `<title>` 앞에 `[branch]` 접두사 추가
  - git 명령 실패 시 원본 HTML 그대로 반환 (안전 fallback)

## 동작 방식
- Vite의 `transformIndexHtml` 훅은 HTML을 클라이언트에 전달하기 직전에 호출됨
- `apply: "serve"`로 개발 서버에서만 플러그인 활성화 → `vite build` 시 플러그인 자체가 로드되지 않음
- 예시: `feat/statusbar-logout` 브랜치 → 탭 제목 `[feat/statusbar-logout] Windows_KDH_Portfolio`

## 테스트
- [x] `tsc --noEmit` 타입체크 통과
- [x] `vite build` 프로덕션 빌드 성공 (플러그인 미적용 확인)
- [ ] 수동 확인: `pnpm dev` 실행 후 브라우저 탭 제목에 브랜치명 표시 여부