### PR TITLE
refactor(skills): 리뷰 루프 — 모든 심각도 처리 + 오케스트레이터 의견

### DIFF
--- a/.claude/skills/orchestrator-review-loop/SKILL.md
+++ b/.claude/skills/orchestrator-review-loop/SKILL.md
@@ -21,10 +21,12 @@ digraph review_loop {
     "PR 컨텍스트 수집" -> "스킬 파일 Read";
     "스킬 파일 Read" -> "diff 수집 (Round 1: 전체, 2+: delta)";
     "diff 수집 (Round 1: 전체, 2+: delta)" -> "Agent: worker-review-code [review-cycle]";
-    "Agent: worker-review-code [review-cycle]" -> "Must Fix 0건?";
-    "Must Fix 0건?" -> "사용자에게 결과 요약" [label="yes → LGTM"];
-    "Must Fix 0건?" -> "Agent: worker-resolve-review" [label="no"];
-    "Agent: worker-resolve-review" -> "diff 수집 (Round 1: 전체, 2+: delta)" [label="다음 라운드"];
+    "Agent: worker-review-code [review-cycle]" -> "지적 0건?";
+    "지적 0건?" -> "사용자에게 결과 요약" [label="yes → LGTM"];
+    "지적 0건?" -> "Agent: worker-resolve-review" [label="no (모든 심각도)"];
+    "Agent: worker-resolve-review" -> "Must Fix 잔여?";
+    "Must Fix 잔여?" -> "diff 수집 (Round 1: 전체, 2+: delta)" [label="yes → 다음 라운드"];
+    "Must Fix 잔여?" -> "오케스트레이터 의견 + 결과 요약" [label="no"];
     "Agent: worker-review-code [review-cycle]" -> "사용자에게 중단 보고" [label="훅 deny"];
 }
 ```
@@ -67,17 +69,22 @@ loop:
   )
 
   if reviewResult == "LGTM":
-    break → Step 4
+    break → Step 4 (LGTM)
 
   // 수정 — 훅이 카운팅하지 않음 ([review-cycle] 마커 없음)
   // resolve는 PR 번호만 받아 gh api로 직접 review comment 수집
+  // 모든 심각도(Must Fix, Should Fix, Suggestion)를 전달 — resolve가 독립 판단
   resolveResult = Agent(
     description="PR #N 리뷰 반영",
     prompt=resolveSkillContent + PR번호
   )
 
-  round++
-  라운드 기록 누적
+  if resolveResult의 Must Fix 잔여 > 0:
+    round++
+    라운드 기록 누적
+    continue  // 다음 리뷰 라운드
+  else:
+    break → Step 4 (의견 포함 보고)
 ```
 
 ### diff 전략
@@ -87,17 +94,26 @@ loop:
 
 ### 루프 탈출 조건
 
-1. **Must Fix 0건 (정상 종료)** — 리뷰 서브에이전트가 "LGTM" 반환
-2. **훅 deny (강제 종료)** — 5사이클 도달, 오케스트레이터가 중단 보고로 전환
+1. **지적 0건 (LGTM)** — 리뷰 서브에이전트가 "LGTM" 반환
+2. **Must Fix 잔여 0건** — resolve 후 Must Fix가 남지 않음 (Should Fix/Suggestion은 resolve가 처리 완료)
+3. **훅 deny (강제 종료)** — 5사이클 도달, 오케스트레이터가 중단 보고로 전환
 
 ## Step 4: 사용자에게 결과 요약
+
+모든 지적 항목(Must Fix, Should Fix, Suggestion)에 대해 오케스트레이터가 자체 판단 의견을 달아 보고한다.
+resolve가 처리한 항목은 처리 결과를, 남은 항목은 오케스트레이터의 반영 여부 의견을 포함한다.
 
 ```
 리뷰 완료: PR #N
 
 - 총 N라운드 실행
-- 수정: N건, 기각: N건, 판단 필요: N건
+- 수정: N건, 부분 수용: N건, 기각: N건, 판단 필요: N건
 - 각 라운드 히스토리는 PR 코멘트에 기록되어 있습니다
+
+{각 항목에 대한 오케스트레이터 의견 — 심각도 무관}
+| 항목 | 심각도 | 처리 | 의견 |
+|------|--------|------|------|
+| `파일:라인` — 제목 | 🔴/🟡/🟢 | ✅수정/❌기각/... | ~~ 해서 반영함/반영 불필요로 판단함/... |
 
 {판단 필요 항목이 있으면}
 아래 항목은 사용자 판단이 필요합니다:

--- a/.claude/skills/worker-resolve-review/SKILL.md
+++ b/.claude/skills/worker-resolve-review/SKILL.md
@@ -66,6 +66,9 @@ gh api repos/{owner}/{repo}/pulls/{pr}/comments \
 ## Step 2: 각 지적 타당성 판단
 
 각 지적마다 **해당 파일의 실제 코드를 읽고** 타당성을 판단한다.
+**심각도와 무관하게 모든 항목(Must Fix, Should Fix, Suggestion)을 독립적으로 판단한다.**
+리뷰어가 🟢 Suggestion으로 표기했더라도 실제로 개선 가치가 있다고 판단되면 수정한다.
+반대로 🔴 Must Fix라도 타당하지 않으면 기각한다. 심각도 라벨이 아닌 기술적 판단이 기준이다.
 
 ### 수정한다 (✅ 수정)
 


### PR DESCRIPTION
## 배경
- 리뷰 루프에서 Must Fix 0건이면 Suggestion/Should Fix를 무시하고 바로 LGTM 종료했음
- 사용자가 직접 PR 코멘트를 확인해야 하는 불편함 + 가치 있는 Suggestion이 누락될 수 있음

## 변경 사항
- `orchestrator-review-loop/SKILL.md`:
  - 플로우 변경: 지적 있으면 심각도 무관하게 resolve 실행
  - 루프 탈출: Must Fix 잔여 0건 기준 (Suggestion/Should Fix는 resolve가 처리)
  - Step 4 결과 요약에 오케스트레이터 의견 테이블 추가
- `worker-resolve-review/SKILL.md`:
  - Step 2에 심각도 독립 판단 원칙 명시 (Suggestion이라도 가치 있으면 수정, Must Fix라도 타당하지 않으면 기각)

## 동작 방식
- 리뷰어가 🟢 Suggestion으로 달아도 resolve가 독립적으로 "반영 가치 있음"으로 판단하면 수정함
- 오케스트레이터는 최종 보고 시 모든 항목에 대해 `~~ 해서 반영함/반영 불필요로 판단함` 형태의 의견을 포함

## 테스트
- [ ] 수동 확인: Suggestion만 있는 PR에 리뷰 루프 실행 → resolve가 동작하는지
- [ ] 수동 확인: 최종 보고에 오케스트레이터 의견 테이블이 포함되는지